### PR TITLE
fix: allow newer provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ provider "pihole" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_pihole"></a> [pihole](#requirement\_pihole) | ~> 0.0.12 |
+| <a name="requirement_pihole"></a> [pihole](#requirement\_pihole) | >= 0.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_pihole"></a> [pihole](#provider\_pihole) | 0.0.12 |
+| <a name="provider_pihole"></a> [pihole](#provider\_pihole) | >= 0.2.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pihole = {
       source  = "ryanwholey/pihole"
-      version = "~> 0.2.0"
+      version = ">= 0.2.0"
     }
   }
 }


### PR DESCRIPTION
Loosen the provider constraint to allow newever provider versions (`2.0.0-beta.1` for PiHole 6)